### PR TITLE
Updated ubuntu2004_gpu Dockerfile specs

### DIFF
--- a/dockerfiles/ubuntu2004_gpu.dockerfile
+++ b/dockerfiles/ubuntu2004_gpu.dockerfile
@@ -1,8 +1,11 @@
-FROM  nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04
+FROM  nvidia/cuda:11.4.3-cudnn8-devel-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /build
+COPY ./scripts/install_latest_cmake.bash install_latest_cmake.bash
+COPY ./scripts/install_onnx_runtime.bash install_onnx_runtime.bash
+COPY ./scripts/install_apps_dependencies.bash install_apps_dependencies.bash
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## **Purpose of Pull Request** :bookmark: 

This is to update the base image used as well as add `COPY` instructions to the file `ubuntu2004_gpu.dockerfile` under directory `dockerfiles`, in order to avoid compilation errors such as missing bash scripts as well as docker base image.

As of `21st September 2024`, realized that Nvidia has removed the now deprecated `nvidia/cuda:11.4.0-cudnn8-devel-ubuntu20.04` from their [DockerHub](https://hub.docker.com/r/nvidia/cuda).

## **Summary** :books: 
- Updated base image to `nvidia/cuda:11.4.3-cudnn8-devel-ubuntu20.04` instead which is still available.
- Added COPY instructions to ensure the custom bash scripts for installing dependencies are present during docker image build process.